### PR TITLE
docs: kernel aggregation + overlay merge (stubs)

### DIFF
--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -1,0 +1,3 @@
+﻿# Kernel Aggregation
+
+(TBD: Claude to fill  explicit Σ harms, ΔΦ_K definition, two worked examples)

--- a/docs/overlay_merge.md
+++ b/docs/overlay_merge.md
@@ -1,0 +1,4 @@
+﻿# Overlay Merge Policy
+
+(TBD: Claude to fill  object-only weights, merge order = header.overlays (leftright, last wins),
+renormalize to 1.0 (fail in --strict if |factor-1| > 10%), examples with KND-K + K_TECH + K_COLLAB)


### PR DESCRIPTION
Adds explicit spec placeholders to be completed before enabling --strict.